### PR TITLE
Draw external borders (around groups of provinces)

### DIFF
--- a/EU3_Scenario_Editor/src/editor/MapPixelData.java
+++ b/EU3_Scenario_Editor/src/editor/MapPixelData.java
@@ -15,6 +15,36 @@ import java.util.List;
 /** @since 0.3pre1 */
 public final class MapPixelData {
     
+    public static final class BorderPixel {
+        private final int x;
+        private final int y;
+        private final int rgb1;
+        private final int rgb2;
+
+        public BorderPixel(int x, int y, int rgb1, int rgb2) {
+            this.x = x;
+            this.y = y;
+            this.rgb1 = rgb1;
+            this.rgb2 = rgb2;
+        }
+
+        public int getX() {
+            return x;
+        }
+
+        public int getY() {
+            return y;
+        }
+
+        public int getRgb1() {
+            return rgb1;
+        }
+
+        public int getRgb2() {
+            return rgb2;
+        }
+    }
+    
     /**
      * Mapping of rgb value to a list of horizontal lines in the province.
      * Each line is kept in an array of size 3.
@@ -24,16 +54,16 @@ public final class MapPixelData {
     private final java.util.Map<Integer, List<Integer[]>> provLines;
     
     /**
-     * List of two-element arrays holding coordinates of border pixels.
+     * List of border pixels and the two province colors the border divides.
      * @since 0.5pre3
      */
-    private final List<Integer[]> borders;
+    private final List<BorderPixel> borders;
     
     private static final int BLACK = 0xFF000000; // java.awt.Color.BLACK.getRGB();
     
     public MapPixelData(final BufferedImage img, final int numProvs) {
         provLines = new HashMap<>(numProvs);
-        java.util.Map<Integer[], Object> tmpBorders = new HashMap<>(numProvs*32);
+        java.util.List<BorderPixel> tmpBorders = new ArrayList<>(numProvs*32);
         
         int rgb;
         
@@ -63,8 +93,11 @@ public final class MapPixelData {
                 points[2] = x;
                 
                 provLines.get(rgb).add(points);
-                if (rgb != BLACK && x < width && rgbLine[x] != BLACK) { // it's PTI, so don't bother with a border
-                    tmpBorders.put(new Integer[] {x,y}, null);
+                if (x < width) {
+                    int rgb2 = rgbLine[x];
+                    if (rgb != BLACK && rgb2 != BLACK) { // it's PTI, so don't bother with a border
+                        tmpBorders.add(new BorderPixel(x, y, rgb, rgb2));
+                    }
                 }
                 
                 x--;
@@ -81,20 +114,23 @@ public final class MapPixelData {
                 do {
                     y++;
                 } while (y < height && rgb == rgbCol[y]);
-                if (rgb != BLACK && y < height && rgbCol[y] != BLACK) { // it's PTI, so don't bother with a border
-                    tmpBorders.put(new Integer[] {x,y}, null);
+                if (y < height) {
+                    int rgb2 = rgbCol[y];
+                    if (rgb != BLACK && rgb2 != BLACK) { // it's PTI, so don't bother with a border
+                        tmpBorders.add(new BorderPixel(x, y, rgb, rgb2));
+                    }
                 }
             }
         }
         
-        borders = new ArrayList<>(tmpBorders.keySet());
+        borders = tmpBorders;
     }
     
     public List<Integer[]> getLinesInProv(int rgb) {
         return provLines.get(rgb);
     }
     
-    public List<Integer[]> getBorderPixels() {
+    public List<BorderPixel> getBorderPixels() {
         return borders;
     }
 }

--- a/EU3_Scenario_Editor/src/editor/MapmodeBuilder.java
+++ b/EU3_Scenario_Editor/src/editor/MapmodeBuilder.java
@@ -295,7 +295,8 @@ public class MapmodeBuilder {
         viewMenu.add(new JSeparator());
         viewMenu.add(new CustomMapModeAction());
         viewMenu.add(new CustomScalingMapModeAction());
-        viewMenu.add(new PaintBordersAction());
+        viewMenu.add(new PaintInternalBordersAction());
+        viewMenu.add(new PaintExternalBordersAction());
         
         log.log(Level.INFO, "Done in {0} ms.", System.currentTimeMillis() - startTime);
     }
@@ -1379,14 +1380,26 @@ public class MapmodeBuilder {
         }
     }
 
-    private static class PaintBordersAction extends AbstractAction {
-        PaintBordersAction() {
-            super("Toggle borders");
+    private static class PaintInternalBordersAction extends AbstractAction {
+        PaintInternalBordersAction() {
+            super("Toggle internal borders");
             putValue(AbstractAction.ACCELERATOR_KEY, KeyStroke.getKeyStroke('B', InputEvent.CTRL_DOWN_MASK));
         }
         @Override
         public void actionPerformed(ActionEvent e) {
-            mapPanel.setPaintBorders(!mapPanel.isPaintBorders());
+            mapPanel.setPaintInternalBorders(!mapPanel.isPaintInternalBorders());
+            mapPanel.repaint();
+        }
+    }
+
+    private static class PaintExternalBordersAction extends AbstractAction {
+        PaintExternalBordersAction() {
+            super("Toggle external borders");
+            putValue(AbstractAction.ACCELERATOR_KEY, KeyStroke.getKeyStroke('B', InputEvent.CTRL_DOWN_MASK | InputEvent.ALT_DOWN_MASK));
+        }
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            mapPanel.setPaintExternalBorders(!mapPanel.isPaintExternalBorders());
             mapPanel.repaint();
         }
     }

--- a/EU3_Scenario_Editor/src/editor/mapmode/AllAreasMapMode.java
+++ b/EU3_Scenario_Editor/src/editor/mapmode/AllAreasMapMode.java
@@ -95,6 +95,18 @@ public class AllAreasMapMode extends ProvincePaintingMode {
     }
 
     @Override
+    public Object getBorderGroup(final int provId) {
+        String area = provinceAreas.get(provId);
+        if (area != null)
+            return area;
+        if (mapPanel.getMap().isWasteland(provId))
+            return "WASTELAND";
+        if (!mapPanel.getMap().isLand(provId))
+            return "SEA_ZONE";
+        return "DEFAULT";
+    }
+
+    @Override
     public String getTooltipExtraText(ProvinceData.Province current) {
         String area = provinceAreas.get(current.getId());
         if (area != null) {

--- a/EU3_Scenario_Editor/src/editor/mapmode/AllClimatesMapMode.java
+++ b/EU3_Scenario_Editor/src/editor/mapmode/AllClimatesMapMode.java
@@ -169,6 +169,25 @@ public class AllClimatesMapMode extends ProvincePaintingMode {
     }
 
     @Override
+    public Object getBorderGroup(final int provId) {
+        final String climate = provinceClimates.get(provId);
+        final String winter = provinceWinters.get(provId);
+        final String monsoon = provinceMonsoons.get(provId);
+
+        if (climateType == ClimateType.CLIMATE)
+            return climate == null ? "DEFAULT" : climate;
+        if (climateType == ClimateType.WINTER)
+            return winter == null ? "DEFAULT" : winter;
+        if (climateType == ClimateType.MONSOON)
+            return monsoon == null ? "DEFAULT" : monsoon;
+
+        String c = (climate == null) ? "-" : climate;
+        String w = (winter == null) ? "-" : winter;
+        String m = (monsoon == null) ? "-" : monsoon;
+        return c + "|" + w + "|" + m;
+    }
+
+    @Override
     public String getTooltipExtraText(ProvinceData.Province current) {
         StringBuilder ret = new StringBuilder();
         

--- a/EU3_Scenario_Editor/src/editor/mapmode/CapitalsMode.java
+++ b/EU3_Scenario_Editor/src/editor/mapmode/CapitalsMode.java
@@ -60,6 +60,16 @@ public final class CapitalsMode extends ProvincePaintingMode {
     }
 
     @Override
+    public Object getBorderGroup(final int provId) {
+        if (!getMap().isLand(provId))
+            return "SEA_ZONE";
+        String country = capitals.get(provId);
+        if (country == null)
+            return "NOT_CAPITAL";
+        return "CAPITAL:" + country;
+    }
+
+    @Override
     public String getTooltipExtraText(final Province current) {
         if (capitals.containsKey(current.getId()))
             return "Capital of " + capitals.get(current.getId());

--- a/EU3_Scenario_Editor/src/editor/mapmode/ColonialRegionsMode.java
+++ b/EU3_Scenario_Editor/src/editor/mapmode/ColonialRegionsMode.java
@@ -97,6 +97,18 @@ public class ColonialRegionsMode extends ProvincePaintingMode {
     }
 
     @Override
+    public Object getBorderGroup(final int provId) {
+        ColonialRegion cr = regions.get(provId);
+        if (cr != null)
+            return cr.getName();
+        if (mapPanel.getMap().isWasteland(provId))
+            return "WASTELAND";
+        if (!mapPanel.getMap().isLand(provId))
+            return "SEA_ZONE";
+        return "DEFAULT";
+    }
+
+    @Override
     public String getTooltipExtraText(ProvinceData.Province current) {
         ColonialRegion cr = regions.get(current.getId());
         if (cr != null) {

--- a/EU3_Scenario_Editor/src/editor/mapmode/CoreMapMode.java
+++ b/EU3_Scenario_Editor/src/editor/mapmode/CoreMapMode.java
@@ -45,6 +45,16 @@ public class CoreMapMode extends ProvincePaintingMode {
         // Sea zones can't be cores.
         return;
     }
+
+    @Override
+    public Object getBorderGroup(final int provId) {
+        if (!getMap().isLand(provId))
+            return "SEA_ZONE";
+        final List<String> coreOf = mapPanel.getModel().isCoreOf(provId);
+        if (coreOf != null && coreOf.contains(tag))
+            return "CORE";
+        return "NOT_CORE";
+    }
     
     @Override
     public String getTooltipExtraText(Province current) {

--- a/EU3_Scenario_Editor/src/editor/mapmode/CountryFlagMode.java
+++ b/EU3_Scenario_Editor/src/editor/mapmode/CountryFlagMode.java
@@ -36,6 +36,13 @@ public class CountryFlagMode extends CountryMode {
     }
 
     @Override
+    protected Object getCountryBorderGroup(String country) {
+        if (country == null || country.isEmpty() || Utilities.isNotACountry(country))
+            return "NO_COUNTRY";
+        return mapPanel.getModel().isRhsSet(country, SET_COUNTRY_FLAG, CLR_COUNTRY_FLAG, flagName);
+    }
+
+    @Override
     public String getTooltipExtraText(ProvinceData.Province current) {
         String owner = mapPanel.getModel().getOwner(current.getId());
         if (Utilities.isNotACountry(owner))

--- a/EU3_Scenario_Editor/src/editor/mapmode/CountryHistoryExistsMode.java
+++ b/EU3_Scenario_Editor/src/editor/mapmode/CountryHistoryExistsMode.java
@@ -45,6 +45,19 @@ public class CountryHistoryExistsMode extends ProvincePaintingMode {
     }
 
     @Override
+    public Object getBorderGroup(final int provId) {
+        if (!getMap().isLand(provId))
+            return "SEA_ZONE";
+
+        final String ownerTag = mapPanel.getModel().getOwner(provId);
+        if (Utilities.isNotACountry(ownerTag))
+            return "NO_COUNTRY";
+
+        final GenericObject history = mapPanel.getDataSource().getCountryHistory(ownerTag);
+        return history != null;
+    }
+
+    @Override
     public String getTooltipExtraText(ProvinceData.Province current) {
         final String ownerTag = mapPanel.getModel().getOwner(current.getId());
         if (Utilities.isNotACountry(ownerTag))

--- a/EU3_Scenario_Editor/src/editor/mapmode/CountryMode.java
+++ b/EU3_Scenario_Editor/src/editor/mapmode/CountryMode.java
@@ -40,6 +40,24 @@ public class CountryMode extends ProvincePaintingMode {
     protected Color getCtryColor(String country) {
         return Utilities.getCtryColor(country);
     }
+
+    protected Object getCountryBorderGroup(String country) {
+        if (country == null || country.isEmpty() || Utilities.isNotACountry(country)) {
+            return "NO_COUNTRY";
+        }
+        return country.toUpperCase();
+    }
+
+    @Override
+    public Object getBorderGroup(final int provId) {
+        if (getMap().isWasteland(provId)) {
+            return "WASTELAND";
+        }
+        if (!getMap().isLand(provId)) {
+            return "SEA_ZONE";
+        }
+        return getCountryBorderGroup(mapPanel.getModel().getOwner(provId));
+    }
     
     @Override
     public String getTooltipExtraText(final Province current) {

--- a/EU3_Scenario_Editor/src/editor/mapmode/CtryReligionMode.java
+++ b/EU3_Scenario_Editor/src/editor/mapmode/CtryReligionMode.java
@@ -47,6 +47,20 @@ public class CtryReligionMode extends CountryMode {
             return Utilities.getReligionColor(religion);
         }
     }
+
+    @Override
+    protected Object getCountryBorderGroup(String country) {
+        if (country == null || country.isEmpty() || Utilities.isNotACountry(country))
+            return "NO_COUNTRY";
+
+        country = country.toUpperCase();
+        final String religion = mapPanel.getModel().getHistString(country, "religion");
+        if (religion == null)
+            return "MISSING";
+        if (religion.length() == 0 || religion.equalsIgnoreCase("none"))
+            return "NONE";
+        return religion;
+    }
     
     
     @Override

--- a/EU3_Scenario_Editor/src/editor/mapmode/CultureGroupMode.java
+++ b/EU3_Scenario_Editor/src/editor/mapmode/CultureGroupMode.java
@@ -44,6 +44,22 @@ public class CultureGroupMode extends ProvincePaintingMode {
     protected void paintSeaZone(Graphics2D g, int id) {
         // do nothing
     }
+
+    @Override
+    public Object getBorderGroup(final int provId) {
+        if (mapPanel.getMap().isWasteland(provId))
+            return "WASTELAND";
+        if (!getMap().isLand(provId))
+            return "SEA_ZONE";
+
+        final String pCulture = mapPanel.getModel().getHistString(provId, "culture");
+        if (pCulture != null) {
+            String pGroup = Utilities.getCultureGroup(pCulture);
+            if (pGroup != null && pGroup.equalsIgnoreCase(this.cultureGroup))
+                return pCulture.toLowerCase();
+        }
+        return "OTHER";
+    }
     
     @Override
     public String getTooltipExtraText(final ProvinceData.Province current) {

--- a/EU3_Scenario_Editor/src/editor/mapmode/CustomCountryMode.java
+++ b/EU3_Scenario_Editor/src/editor/mapmode/CustomCountryMode.java
@@ -52,6 +52,18 @@ public class CustomCountryMode extends CountryMode {
         else
             return notFoundColor;
     }
+
+    @Override
+    protected Object getCountryBorderGroup(String country) {
+        if (country == null || country.isEmpty() || Utilities.isNotACountry(country))
+            return "NO_COUNTRY";
+
+        country = country.toUpperCase();
+        String histValue = mapPanel.getModel().getHistString(country, name);
+        if (histValue == null)
+            return "MISSING";
+        return value.equals(histValue.toLowerCase());
+    }
     
     @Override
     public String getTooltipExtraText(final Province current) {

--- a/EU3_Scenario_Editor/src/editor/mapmode/CustomMode.java
+++ b/EU3_Scenario_Editor/src/editor/mapmode/CustomMode.java
@@ -60,6 +60,27 @@ public class CustomMode extends ProvincePaintingMode {
         // Default is to do nothing
         return;
     }
+
+    @Override
+    public Object getBorderGroup(final int provId) {
+        if (getMap().isWasteland(provId)) {
+            return "WASTELAND";
+        }
+        if (!getMap().isLand(provId)) {
+            return "SEA_ZONE";
+        }
+
+        String prop;
+        if (isOwner)
+            prop = mapPanel.getModel().getOwner(provId);
+        else
+            prop = mapPanel.getModel().getHistString(provId, name);
+
+        if (prop == null)
+            return "MISSING";
+
+        return value.equals(prop.toLowerCase());
+    }
     
     @Override
     public String getTooltipExtraText(final Province current) {

--- a/EU3_Scenario_Editor/src/editor/mapmode/DeJureTitleMode.java
+++ b/EU3_Scenario_Editor/src/editor/mapmode/DeJureTitleMode.java
@@ -20,8 +20,6 @@ import java.util.List;
  */
 public class DeJureTitleMode extends ProvincePaintingMode {
 
-    private static final float EXTERNAL_BORDER_MULTIPLIER = 3.0f;
-    
     protected CK2DataSource dataSource;
     protected CK3DataSource ck3DataSource;
     
@@ -210,11 +208,4 @@ public class DeJureTitleMode extends ProvincePaintingMode {
         return provId;
     }
 
-    @Override
-    public float getBorderThicknessMultiplier(final int provId1, final int provId2, final Object group1, final Object group2) {
-        if (java.util.Objects.equals(group1, group2)) {
-            return 1.0f;
-        }
-        return EXTERNAL_BORDER_MULTIPLIER;
-    }
 }

--- a/EU3_Scenario_Editor/src/editor/mapmode/DeJureTitleMode.java
+++ b/EU3_Scenario_Editor/src/editor/mapmode/DeJureTitleMode.java
@@ -19,6 +19,8 @@ import java.util.List;
  * @since 0.9.13
  */
 public class DeJureTitleMode extends ProvincePaintingMode {
+
+    private static final float EXTERNAL_BORDER_MULTIPLIER = 3.0f;
     
     protected CK2DataSource dataSource;
     protected CK3DataSource ck3DataSource;
@@ -197,5 +199,22 @@ public class DeJureTitleMode extends ProvincePaintingMode {
 //            return titleName;
 //
 //        return "Unknown owner";
+    }
+
+    @Override
+    public Object getBorderGroup(final int provId) {
+        final String title = provinceTitles.get(provId);
+        if (title != null && !title.isEmpty()) {
+            return title;
+        }
+        return provId;
+    }
+
+    @Override
+    public float getBorderThicknessMultiplier(final int provId1, final int provId2, final Object group1, final Object group2) {
+        if (java.util.Objects.equals(group1, group2)) {
+            return 1.0f;
+        }
+        return EXTERNAL_BORDER_MULTIPLIER;
     }
 }

--- a/EU3_Scenario_Editor/src/editor/mapmode/DiscreteCountryScalingMapMode.java
+++ b/EU3_Scenario_Editor/src/editor/mapmode/DiscreteCountryScalingMapMode.java
@@ -94,6 +94,20 @@ public class DiscreteCountryScalingMapMode extends CountryMode {
         
         return colors[index];
     }
+
+    @Override
+    protected Object getCountryBorderGroup(String countryTag) {
+        if (countryTag == null || countryTag.isEmpty() || Utilities.isNotACountry(countryTag))
+            return "NO_COUNTRY";
+
+        String value = mapPanel.getModel().getHistString(countryTag, prop);
+        if (value == null || value.length() == 0)
+            value = "0";
+
+        int index = (int) ((Double.parseDouble(value) + min) / step);
+        index = Math.max(0, Math.min(numColors-1, index));
+        return index;
+    }
     
     @Override
     protected void paintSeaZone(final Graphics2D g, int id) {

--- a/EU3_Scenario_Editor/src/editor/mapmode/DiscreteScalingMapMode.java
+++ b/EU3_Scenario_Editor/src/editor/mapmode/DiscreteScalingMapMode.java
@@ -80,6 +80,25 @@ public class DiscreteScalingMapMode extends ProvincePaintingMode {
         
         return Double.parseDouble(value);
     }
+
+    @Override
+    public Object getBorderGroup(final int provId) {
+        if (getMap().isWasteland(provId)) {
+            return "WASTELAND";
+        }
+        if (!getMap().isLand(provId)) {
+            return "SEA_ZONE";
+        }
+
+        final double value = getProvinceValue(provId);
+        if (value < 0) {
+            return "NONE";
+        }
+
+        int index = (int) ((value + min) / step);
+        index = Math.max(0, Math.min(colors.length-1, index));
+        return index;
+    }
     
     @Override
     protected void paintSeaZone(final Graphics2D g, int id) {

--- a/EU3_Scenario_Editor/src/editor/mapmode/GoodsMode.java
+++ b/EU3_Scenario_Editor/src/editor/mapmode/GoodsMode.java
@@ -58,6 +58,21 @@ public class GoodsMode extends ProvincePaintingMode {
     protected void paintSeaZone(Graphics2D g, int id) {
         // Do nothing
     }
+
+    @Override
+    public Object getBorderGroup(final int provId) {
+        if (getMap().isWasteland(provId))
+            return "WASTELAND";
+        if (!getMap().isLand(provId))
+            return "SEA_ZONE";
+
+        final String goods = mapPanel.getModel().getHistString(provId, "trade_goods");
+        if (goods == null)
+            return "MISSING";
+        if (goods.length() == 0 || goods.equalsIgnoreCase("none"))
+            return "NONE";
+        return goods.toLowerCase();
+    }
     
     
     @Override

--- a/EU3_Scenario_Editor/src/editor/mapmode/GroupMode.java
+++ b/EU3_Scenario_Editor/src/editor/mapmode/GroupMode.java
@@ -54,4 +54,9 @@ public class GroupMode extends ProvincePaintingMode {
             mapPanel.paintProvince(g, id, foundColor);
         }
     }
+
+    @Override
+    public Object getBorderGroup(final int provId) {
+        return provIds.contains(provId);
+    }
 }

--- a/EU3_Scenario_Editor/src/editor/mapmode/HistoryExistsMode.java
+++ b/EU3_Scenario_Editor/src/editor/mapmode/HistoryExistsMode.java
@@ -36,6 +36,11 @@ public class HistoryExistsMode extends ProvincePaintingMode {
     }
 
     @Override
+    public Object getBorderGroup(final int provId) {
+        return mapPanel.getDataSource().getProvinceHistory(provId) != null;
+    }
+
+    @Override
     public String getTooltipExtraText(ProvinceData.Province current) {
         if (mapPanel.getDataSource().getProvinceHistory(current.getId()) == null)
             return "Does not have a history file";

--- a/EU3_Scenario_Editor/src/editor/mapmode/HistorySimpleTerrainMode.java
+++ b/EU3_Scenario_Editor/src/editor/mapmode/HistorySimpleTerrainMode.java
@@ -37,6 +37,17 @@ public class HistorySimpleTerrainMode extends ProvincePaintingMode {
     }
 
     @Override
+    public Object getBorderGroup(final int provId) {
+        if (!getMap().isLand(provId))
+            return "SEA_ZONE";
+
+        String terrain = mapPanel.getModel().getHistString(provId, "terrain");
+        if (terrain == null || terrain.isEmpty())
+            return "DEFAULT";
+        return terrain;
+    }
+
+    @Override
     public String getTooltipExtraText(ProvinceData.Province current) {
         String terr = mapPanel.getModel().getHistString(current.getId(), "terrain");
         if (terr != null) {

--- a/EU3_Scenario_Editor/src/editor/mapmode/HotspotMode.java
+++ b/EU3_Scenario_Editor/src/editor/mapmode/HotspotMode.java
@@ -21,26 +21,16 @@ public class HotspotMode extends DiscreteScalingMapMode {
     }
 
     @Override
-    protected void paintProvince(Graphics2D g, int provId) {
-        List<String> strings = mapPanel.getModel().getHistStrings(provId, prop); // not very efficient - could precalculate some of this maybe
-        int count;
+    protected double getProvinceValue(int provId) {
+        List<String> strings = mapPanel.getModel().getHistStrings(provId, prop);
+        if (strings != null && !strings.isEmpty())
+            return strings.size();
         
-        if (strings != null && !strings.isEmpty()) {
-            count = strings.size();
-        } else {
-            List<GenericObject> objects = mapPanel.getModel().getHistObjects(provId, prop);
-            if (objects != null) {
-                count = objects.size();
-            } else {
-                mapPanel.paintProvince(g, provId, Utilities.COLOR_LAND_DEFAULT);
-                return;
-            }
-        }
+        List<GenericObject> objects = mapPanel.getModel().getHistObjects(provId, prop);
+        if (objects != null)
+            return objects.size();
         
-        int index = (int) ((count + 0.0) / getStep());
-        index = Math.max(0, Math.min(colors.length-1, index));
-        
-        mapPanel.paintProvince(g, provId, colors[index]);
+        return 0;
     }
 
     @Override
@@ -53,18 +43,7 @@ public class HotspotMode extends DiscreteScalingMapMode {
         if (!getMap().isLand(id))
             return "";
         
-        List<String> strings = mapPanel.getModel().getHistStrings(id, prop);
-        int count = -1;
-        
-        if (strings != null && !strings.isEmpty()) {
-            count = strings.size();
-        } else {
-            List<GenericObject> objects = mapPanel.getModel().getHistObjects(id, prop);
-            if (objects != null) {
-                count = objects.size();
-            }
-        }
-        return "\"" + prop + "\" changes: " + count;
+        return prop + " changes: " + (int)getProvinceValue(id);
     }
     
     @Override

--- a/EU3_Scenario_Editor/src/editor/mapmode/IsPlayerMapMode.java
+++ b/EU3_Scenario_Editor/src/editor/mapmode/IsPlayerMapMode.java
@@ -43,6 +43,21 @@ public class IsPlayerMapMode extends CountryMode {
             return notFoundColor;
         }
     }
+
+    @Override
+    protected Object getCountryBorderGroup(String country) {
+        if (country == null || country.isEmpty() || Utilities.isNotACountry(country))
+            return "NO_COUNTRY";
+
+        country = country.toUpperCase();
+        if (saveGame == null)
+            return country;
+
+        boolean player = saveGame.getCountry(country).getBoolean("was_player");
+        if (player)
+            return country;
+        return "NOT_PLAYER";
+    }
     
 
     @Override

--- a/EU3_Scenario_Editor/src/editor/mapmode/MapMode.java
+++ b/EU3_Scenario_Editor/src/editor/mapmode/MapMode.java
@@ -55,5 +55,13 @@ public abstract class MapMode {
         return "";
     }
 
+    public Object getBorderGroup(final int provId) {
+        return provId;
+    }
+
+    public float getBorderThicknessMultiplier(final int provId1, final int provId2, final Object group1, final Object group2) {
+        return 1.0f;
+    }
+
     public abstract boolean paintsBorders();
 }

--- a/EU3_Scenario_Editor/src/editor/mapmode/PoliticalMode.java
+++ b/EU3_Scenario_Editor/src/editor/mapmode/PoliticalMode.java
@@ -52,6 +52,24 @@ public final class PoliticalMode extends ProvincePaintingMode {
         // do nothing
     }
 
+    @Override
+    public Object getBorderGroup(final int provId) {
+        if (!getMap().isLand(provId)) {
+            return "SEA_ZONE";
+        }
+
+        final String owner = mapPanel.getModel().getOwner(provId);
+        if (owner == null || owner.isEmpty()) {
+            return "NO_OWNER";
+        }
+
+        String controller = getController(provId);
+        if (controller == null || controller.isEmpty())
+            controller = owner;
+
+        return owner.toUpperCase() + "|" + controller.toUpperCase();
+    }
+
     private String getController(int provId) {
         String controller = mapPanel.getModel().getHistString(provId, "controller");
         if (controller.isEmpty()) {

--- a/EU3_Scenario_Editor/src/editor/mapmode/PopCultureMode.java
+++ b/EU3_Scenario_Editor/src/editor/mapmode/PopCultureMode.java
@@ -95,6 +95,16 @@ public class PopCultureMode extends PopMode {
     }
 
     @Override
+    public Object getBorderGroup(final int provId) {
+        if (!mapPanel.getMap().isLand(provId))
+            return "SEA_ZONE";
+        String topCulture = provCultures.get(provId);
+        if (topCulture == null)
+            return "NO_POPS";
+        return topCulture;
+    }
+
+    @Override
     public String getTooltipExtraText(ProvinceData.Province current) {
         int provId = current.getId();
         if (!mapPanel.getMap().isLand(provId))

--- a/EU3_Scenario_Editor/src/editor/mapmode/PopReligionMode.java
+++ b/EU3_Scenario_Editor/src/editor/mapmode/PopReligionMode.java
@@ -95,6 +95,16 @@ public class PopReligionMode extends PopMode {
     }
 
     @Override
+    public Object getBorderGroup(final int provId) {
+        if (!mapPanel.getMap().isLand(provId))
+            return "SEA_ZONE";
+        String topReligion = provReligions.get(provId);
+        if (topReligion == null)
+            return "NO_POPS";
+        return topReligion;
+    }
+
+    @Override
     public String getTooltipExtraText(ProvinceData.Province current) {
         int provId = current.getId();
         if (!mapPanel.getMap().isLand(provId))

--- a/EU3_Scenario_Editor/src/editor/mapmode/PopSplitMapMode.java
+++ b/EU3_Scenario_Editor/src/editor/mapmode/PopSplitMapMode.java
@@ -57,6 +57,13 @@ public class PopSplitMapMode extends ProvincePaintingMode {
     }
 
     @Override
+    public Object getBorderGroup(final int provId) {
+        if (!getMap().isLand(provId))
+            return "SEA_ZONE";
+        return mapPanel.getModel().getHistString(provId, "split");
+    }
+
+    @Override
     public String getTooltipExtraText(final Province current) {
         final int id = current.getId();
         if (!getMap().isLand(id))

--- a/EU3_Scenario_Editor/src/editor/mapmode/PopTypeMode.java
+++ b/EU3_Scenario_Editor/src/editor/mapmode/PopTypeMode.java
@@ -89,6 +89,16 @@ public class PopTypeMode extends PopMode {
     }
 
     @Override
+    public Object getBorderGroup(final int provId) {
+        if (!mapPanel.getMap().isLand(provId))
+            return "SEA_ZONE";
+        String topPopType = provTypes.get(provId);
+        if (topPopType == null)
+            return "NO_POPS";
+        return topPopType;
+    }
+
+    @Override
     public String getTooltipExtraText(ProvinceData.Province current) {
         int provId = current.getId();
         if (!mapPanel.getMap().isLand(provId))

--- a/EU3_Scenario_Editor/src/editor/mapmode/ProvCultureMode.java
+++ b/EU3_Scenario_Editor/src/editor/mapmode/ProvCultureMode.java
@@ -40,6 +40,21 @@ public class ProvCultureMode extends ProvincePaintingMode {
     protected void paintSeaZone(final Graphics2D g, int id) {
         // Do nothing
     }
+
+    @Override
+    public Object getBorderGroup(final int provId) {
+        if (mapPanel.getMap().isWasteland(provId))
+            return "WASTELAND";
+        if (!getMap().isLand(provId))
+            return "SEA_ZONE";
+
+        final String culture = mapPanel.getModel().getHistString(provId, "culture");
+        if (culture == null)
+            return "MISSING";
+        if (culture.length() == 0 || culture.equalsIgnoreCase("none"))
+            return "NONE";
+        return culture.toLowerCase();
+    }
     
     @Override
     public String getTooltipExtraText(final Province current) {

--- a/EU3_Scenario_Editor/src/editor/mapmode/ProvReligionMode.java
+++ b/EU3_Scenario_Editor/src/editor/mapmode/ProvReligionMode.java
@@ -44,6 +44,21 @@ public class ProvReligionMode extends ProvincePaintingMode {
         // Do nothing
         return;
     }
+
+    @Override
+    public Object getBorderGroup(final int provId) {
+        if (mapPanel.getMap().isWasteland(provId))
+            return "WASTELAND";
+        if (!getMap().isLand(provId))
+            return "SEA_ZONE";
+
+        final String religion = mapPanel.getModel().getHistString(provId, "religion");
+        if (religion == null)
+            return "MISSING";
+        if (religion.length() == 0 || religion.equalsIgnoreCase("none"))
+            return "NONE";
+        return religion.toLowerCase();
+    }
     
     @Override
     public String getTooltipExtraText(final Province current) {

--- a/EU3_Scenario_Editor/src/editor/mapmode/ProvinceFlagMode.java
+++ b/EU3_Scenario_Editor/src/editor/mapmode/ProvinceFlagMode.java
@@ -45,6 +45,13 @@ public class ProvinceFlagMode extends ProvincePaintingMode {
     protected void paintSeaZone(Graphics2D g, int id) {
         // probably don't care about sea zones - who is setting flags on them?
     }
+
+    @Override
+    public Object getBorderGroup(final int provId) {
+        if (!getMap().isLand(provId))
+            return "SEA_ZONE";
+        return mapPanel.getModel().isRhsSet(provId, SET_PROVINCE_FLAG, CLR_PROVINCE_FLAG, flagName);
+    }
     
     @Override
     public String getTooltipExtraText(ProvinceData.Province current) {

--- a/EU3_Scenario_Editor/src/editor/mapmode/ProvincePaintingMode.java
+++ b/EU3_Scenario_Editor/src/editor/mapmode/ProvincePaintingMode.java
@@ -20,6 +20,8 @@ import java.awt.Paint;
  */
 public abstract class ProvincePaintingMode extends MapMode {
     
+    protected static final float EXTERNAL_BORDER_MULTIPLIER = 3.0f;
+
     private static final Paint background = new Color(15, 100, 255);
     
     protected ProvincePaintingMode() {
@@ -86,6 +88,14 @@ public abstract class ProvincePaintingMode extends MapMode {
     @Override
     public boolean paintsBorders() {
         return true;
+    }
+
+    @Override
+    public float getBorderThicknessMultiplier(final int provId1, final int provId2, final Object group1, final Object group2) {
+        if (java.util.Objects.equals(group1, group2)) {
+            return 1.0f;
+        }
+        return EXTERNAL_BORDER_MULTIPLIER;
     }
 
 }

--- a/EU3_Scenario_Editor/src/editor/mapmode/ReligionMode.java
+++ b/EU3_Scenario_Editor/src/editor/mapmode/ReligionMode.java
@@ -75,6 +75,26 @@ public final class ReligionMode extends ProvincePaintingMode {
     protected void paintSeaZone(final Graphics2D g, int id) {
         // do nothing
     }
+
+    @Override
+    public Object getBorderGroup(final int provId) {
+        if (getMap().isWasteland(provId))
+            return "WASTELAND";
+        if (!getMap().isLand(provId))
+            return "SEA_ZONE";
+
+        final String religion = mapPanel.getModel().getHistString(provId, "religion");
+        if (religion == null)
+            return "MISSING";
+        if (religion.length() == 0 || religion.equalsIgnoreCase("none"))
+            return "NONE";
+
+        final String owner = mapPanel.getModel().getOwner(provId);
+        final String ownerRel = (owner == null) ? null : ctryReligions.get(owner.toUpperCase());
+        if (ownerRel == null || religion.equalsIgnoreCase(ownerRel))
+            return "REL:" + religion.toLowerCase();
+        return "REL:" + religion.toLowerCase() + "|OWNER_REL:" + ownerRel.toLowerCase();
+    }
     
     
     @Override

--- a/EU3_Scenario_Editor/src/editor/mapmode/SimpleTerrainMode.java
+++ b/EU3_Scenario_Editor/src/editor/mapmode/SimpleTerrainMode.java
@@ -59,6 +59,18 @@ public class SimpleTerrainMode extends ProvincePaintingMode {
     }
 
     @Override
+    public Object getBorderGroup(final int provId) {
+        String terr = provTerrains.get(provId);
+        if (terr != null)
+            return terr;
+        if (getMap().isWasteland(provId))
+            return "WASTELAND";
+        if (!getMap().isLand(provId))
+            return "SEA_ZONE";
+        return "DEFAULT";
+    }
+
+    @Override
     public String getTooltipExtraText(ProvinceData.Province current) {
         String terr = provTerrains.get(current.getId());
         if (terr != null) {

--- a/EU3_Scenario_Editor/src/editor/mapmode/TitleMode.java
+++ b/EU3_Scenario_Editor/src/editor/mapmode/TitleMode.java
@@ -88,6 +88,33 @@ public class TitleMode extends ProvincePaintingMode {
     protected void paintSeaZone(final Graphics2D g, int id) {
         // Don't paint sea zones.
     }
+
+    @Override
+    public Object getBorderGroup(final int provId) {
+        if (!getMap().isLand(provId)) {
+            return "SEA_ZONE";
+        }
+        if (getMap().isWasteland(provId)) {
+            return "WASTELAND";
+        }
+
+        String owner = getLowestHistTitleHolder(provId);
+        if (owner == null || owner.isEmpty()) {
+            GenericObject history = getProvinceHistory(provId);
+            if (history != null) {
+                for (GenericObject obj : history.children) {
+                    if (obj.name.startsWith("b_")) {
+                        owner = getLiege(obj.name);
+                        break;
+                    }
+                }
+            }
+        }
+        owner = getLiege(owner);
+        if (owner == null || owner.isEmpty())
+            return "NO_TITLE";
+        return owner;
+    }
     
     protected String getLowestHistTitleHolder(int provId) {
         String title = mapPanel.getModel().getHistString(provId, "title");

--- a/EU3_Scenario_Editor/src/editor/mapmode/TradeMode.java
+++ b/EU3_Scenario_Editor/src/editor/mapmode/TradeMode.java
@@ -122,6 +122,20 @@ public class TradeMode extends ProvincePaintingMode {
     }
 
     @Override
+    public Object getBorderGroup(final int provId) {
+        if (tradeNodes.containsKey(provId))
+            return provId;
+        Integer node = nodeMembers.get(provId);
+        if (node != null)
+            return node;
+        if (getMap().isWasteland(provId))
+            return "WASTELAND";
+        if (!getMap().isLand(provId))
+            return "SEA_ZONE";
+        return "UNKNOWN";
+    }
+
+    @Override
     protected void paintingEnded(Graphics2D g) {
         for (Integer node : tradeNodes.keySet()) {
             List<List<Integer>> targets = outgoing.get(node);


### PR DESCRIPTION
Handles point 1. of #32.

Split "Toggle borders" into two toggles:
<img width="228" height="45" alt="obraz" src="https://github.com/user-attachments/assets/331cbfa6-6b5f-4a5d-b637-4dfedf31118d" />

Added province grouping for all the map modes. Here's the de jure duchies mode:

- internal ON, external ON:
<img width="612" height="506" alt="obraz" src="https://github.com/user-attachments/assets/ab8efbac-d7b6-48fc-94fb-76956cbfd516" />

- internal ON, external OFF:
<img width="612" height="506" alt="obraz" src="https://github.com/user-attachments/assets/d36ef1c3-855d-455a-ab20-5d7e423c40ad" />

- internal OFF, external ON:
<img width="612" height="506" alt="obraz" src="https://github.com/user-attachments/assets/51a68bf3-146a-4295-b76f-04e68917a8b9" />

- internal OFF, external OFF:
<img width="612" height="506" alt="obraz" src="https://github.com/user-attachments/assets/9088423e-11b5-4edb-9609-b5ab6d8dba4b" />